### PR TITLE
Error on invalid stream

### DIFF
--- a/src/EventStore/Exception/StreamDeletedException.php
+++ b/src/EventStore/Exception/StreamDeletedException.php
@@ -1,0 +1,6 @@
+<?php
+namespace EventStore\Exception;
+
+class StreamDeletedException extends \Exception
+{
+}

--- a/src/EventStore/Exception/StreamNotFoundException.php
+++ b/src/EventStore/Exception/StreamNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+namespace EventStore\Exception;
+
+class StreamNotFoundException extends \Exception
+{
+}

--- a/src/EventStore/Http/ResponseCode.php
+++ b/src/EventStore/Http/ResponseCode.php
@@ -1,0 +1,72 @@
+<?php
+namespace EventStore\Http;
+
+/**
+ * Class ResponseCode
+ * Constants from Symfony 2
+ * @author Fabien Potencier
+ * @package EventStore\Http
+ */
+final class ResponseCode
+{
+    const HTTP_CONTINUE = 100;
+    const HTTP_SWITCHING_PROTOCOLS = 101;
+    const HTTP_PROCESSING = 102;            // RFC2518
+    const HTTP_OK = 200;
+    const HTTP_CREATED = 201;
+    const HTTP_ACCEPTED = 202;
+    const HTTP_NON_AUTHORITATIVE_INFORMATION = 203;
+    const HTTP_NO_CONTENT = 204;
+    const HTTP_RESET_CONTENT = 205;
+    const HTTP_PARTIAL_CONTENT = 206;
+    const HTTP_MULTI_STATUS = 207;          // RFC4918
+    const HTTP_ALREADY_REPORTED = 208;      // RFC5842
+    const HTTP_IM_USED = 226;               // RFC3229
+    const HTTP_MULTIPLE_CHOICES = 300;
+    const HTTP_MOVED_PERMANENTLY = 301;
+    const HTTP_FOUND = 302;
+    const HTTP_SEE_OTHER = 303;
+    const HTTP_NOT_MODIFIED = 304;
+    const HTTP_USE_PROXY = 305;
+    const HTTP_RESERVED = 306;
+    const HTTP_TEMPORARY_REDIRECT = 307;
+    const HTTP_PERMANENTLY_REDIRECT = 308;  // RFC-reschke-http-status-308-07
+    const HTTP_BAD_REQUEST = 400;
+    const HTTP_UNAUTHORIZED = 401;
+    const HTTP_PAYMENT_REQUIRED = 402;
+    const HTTP_FORBIDDEN = 403;
+    const HTTP_NOT_FOUND = 404;
+    const HTTP_METHOD_NOT_ALLOWED = 405;
+    const HTTP_NOT_ACCEPTABLE = 406;
+    const HTTP_PROXY_AUTHENTICATION_REQUIRED = 407;
+    const HTTP_REQUEST_TIMEOUT = 408;
+    const HTTP_CONFLICT = 409;
+    const HTTP_GONE = 410;
+    const HTTP_LENGTH_REQUIRED = 411;
+    const HTTP_PRECONDITION_FAILED = 412;
+    const HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+    const HTTP_REQUEST_URI_TOO_LONG = 414;
+    const HTTP_UNSUPPORTED_MEDIA_TYPE = 415;
+    const HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    const HTTP_EXPECTATION_FAILED = 417;
+    const HTTP_I_AM_A_TEAPOT = 418;                                               // RFC2324
+    const HTTP_UNPROCESSABLE_ENTITY = 422;                                        // RFC4918
+    const HTTP_LOCKED = 423;                                                      // RFC4918
+    const HTTP_FAILED_DEPENDENCY = 424;                                           // RFC4918
+    const HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL = 425;   // RFC2817
+    const HTTP_UPGRADE_REQUIRED = 426;                                            // RFC2817
+    const HTTP_PRECONDITION_REQUIRED = 428;                                       // RFC6585
+    const HTTP_TOO_MANY_REQUESTS = 429;                                           // RFC6585
+    const HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;                             // RFC6585
+    const HTTP_INTERNAL_SERVER_ERROR = 500;
+    const HTTP_NOT_IMPLEMENTED = 501;
+    const HTTP_BAD_GATEWAY = 502;
+    const HTTP_SERVICE_UNAVAILABLE = 503;
+    const HTTP_GATEWAY_TIMEOUT = 504;
+    const HTTP_VERSION_NOT_SUPPORTED = 505;
+    const HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL = 506;                        // RFC2295
+    const HTTP_INSUFFICIENT_STORAGE = 507;                                        // RFC4918
+    const HTTP_LOOP_DETECTED = 508;                                               // RFC5842
+    const HTTP_NOT_EXTENDED = 510;                                                // RFC2774
+    const HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511;                             // RFC6585
+}

--- a/tests/EventStore/Tests/EventStoreTest.php
+++ b/tests/EventStore/Tests/EventStoreTest.php
@@ -165,6 +165,27 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     * @expectedException EventStore\Exception\StreamNotFoundException
+     */
+    public function unexistent_stream_should_throw_not_found_exception()
+    {
+        $this->es->openStreamFeed('this-stream-does-not-exists');
+    }
+
+    /**
+     * @test
+     * @expectedException EventStore\Exception\StreamDeletedException
+     */
+    public function deleted_stream_should_throw_an_exception()
+    {
+        $streamName = $this->prepareTestStream();
+        $this->es->deleteStream($streamName, StreamDeletion::HARD());
+
+        $this->es->openStreamFeed($streamName);
+    }
+
+    /**
      * @param  int    $length
      * @return string
      */


### PR DESCRIPTION
If a stream is not available or deleted the construction of the StreamFeed should be prevented and throw an exception that can be handled.

Occured error:
Catchable fatal error: Argument 1 passed to EventStore\StreamFeed\StreamFeed::__construct() must be of the type array, null given in EventStore line 236
