### PR TITLE
Add declare(strict_types=1) to entire codebase

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,6 +14,7 @@ return (new Config())
     ->setRules([
         '@Symfony' => true,
         '@PSR12' => true,
+        'declare_strict_types' => true,
         'php_unit_method_casing' => ['case' => 'snake_case'],
     ])
     ->setRiskyAllowed(true)

--- a/benchmark/read-stream.php
+++ b/benchmark/read-stream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require __DIR__.'/../vendor/autoload.php';
 
 use KurrentDB\EventStore;

--- a/src/EventStore.php
+++ b/src/EventStore.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 use KurrentDB\Exception\ConnectionFailedException;
@@ -371,6 +373,6 @@ final class EventStore implements EventStoreInterface
 
     private function lastResponseAsJson(): array
     {
-        return json_decode($this->lastResponse->getBody(), true);
+        return json_decode((string) $this->lastResponse->getBody(), true);
     }
 }

--- a/src/EventStoreInterface.php
+++ b/src/EventStoreInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 use KurrentDB\StreamFeed\EntryEmbedMode;

--- a/src/Exception/ConnectionFailedException.php
+++ b/src/Exception/ConnectionFailedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/EventStoreException.php
+++ b/src/Exception/EventStoreException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/InvalidWritableEventObjectException.php
+++ b/src/Exception/InvalidWritableEventObjectException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/NetworkException.php
+++ b/src/Exception/NetworkException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/NoExtractableEventVersionException.php
+++ b/src/Exception/NoExtractableEventVersionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/StreamDeletedException.php
+++ b/src/Exception/StreamDeletedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/StreamException.php
+++ b/src/Exception/StreamException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/StreamGoneException.php
+++ b/src/Exception/StreamGoneException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 final class StreamGoneException extends StreamException

--- a/src/Exception/StreamNotFoundException.php
+++ b/src/Exception/StreamNotFoundException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/WriteException.php
+++ b/src/Exception/WriteException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/Exception/WrongExpectedVersionException.php
+++ b/src/Exception/WrongExpectedVersionException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Exception;
 
 /**

--- a/src/ExpectedVersion.php
+++ b/src/ExpectedVersion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 /**

--- a/src/Http/Exception/ClientException.php
+++ b/src/Http/Exception/ClientException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Http\Exception;
 
 use GuzzleHttp\Exception\RequestException as RequestExceptionAlias;

--- a/src/Http/Exception/RequestException.php
+++ b/src/Http/Exception/RequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Http\Exception;
 
 class RequestException extends \RuntimeException

--- a/src/Http/GuzzleHttpClient.php
+++ b/src/Http/GuzzleHttpClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Http;
 
 use Exception as PhpException;

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Http;
 
 use Psr\Http\Client\ClientInterface;

--- a/src/Http/ResponseCode.php
+++ b/src/Http/ResponseCode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Http;
 
 /**

--- a/src/StreamDeletion.php
+++ b/src/StreamDeletion.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 enum StreamDeletion: string

--- a/src/StreamFeed/Entry.php
+++ b/src/StreamFeed/Entry.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 /**

--- a/src/StreamFeed/EntryEmbedMode.php
+++ b/src/StreamFeed/EntryEmbedMode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 enum EntryEmbedMode: string

--- a/src/StreamFeed/EntryWithEvent.php
+++ b/src/StreamFeed/EntryWithEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 final readonly class EntryWithEvent

--- a/src/StreamFeed/Event.php
+++ b/src/StreamFeed/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 use KurrentDB\ValueObjects\Identity\UUID;

--- a/src/StreamFeed/HasLinks.php
+++ b/src/StreamFeed/HasLinks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 /**

--- a/src/StreamFeed/LinkRelation.php
+++ b/src/StreamFeed/LinkRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 enum LinkRelation: string

--- a/src/StreamFeed/StreamFeed.php
+++ b/src/StreamFeed/StreamFeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 /**

--- a/src/StreamFeed/StreamFeedIterator.php
+++ b/src/StreamFeed/StreamFeedIterator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 use KurrentDB\EventStoreInterface;

--- a/src/StreamFeed/StreamUrl.php
+++ b/src/StreamFeed/StreamUrl.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\StreamFeed;
 
 final readonly class StreamUrl implements \Stringable

--- a/src/ValueObjects/Exception/InvalidNativeArgumentException.php
+++ b/src/ValueObjects/Exception/InvalidNativeArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Exception;
 
 class InvalidNativeArgumentException extends \InvalidArgumentException

--- a/src/ValueObjects/Identity/UUID.php
+++ b/src/ValueObjects/Identity/UUID.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Identity;
 
 use KurrentDB\ValueObjects\Exception\InvalidNativeArgumentException;

--- a/src/ValueObjects/StringLiteral/BasicStringLiteral.php
+++ b/src/ValueObjects/StringLiteral/BasicStringLiteral.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\StringLiteral;
 
 final readonly class BasicStringLiteral extends StringLiteral

--- a/src/ValueObjects/StringLiteral/StringLiteral.php
+++ b/src/ValueObjects/StringLiteral/StringLiteral.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\StringLiteral;
 
 use Cassandra\Value;

--- a/src/ValueObjects/Util/Util.php
+++ b/src/ValueObjects/Util/Util.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Util;
 
 /**

--- a/src/ValueObjects/ValueObjectInterface.php
+++ b/src/ValueObjects/ValueObjectInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects;
 
 interface ValueObjectInterface extends \Stringable

--- a/src/WritableEvent.php
+++ b/src/WritableEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 use KurrentDB\ValueObjects\Identity\UUID;

--- a/src/WritableEventCollection.php
+++ b/src/WritableEventCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 use KurrentDB\Exception\InvalidWritableEventObjectException;

--- a/src/WritableToStream.php
+++ b/src/WritableToStream.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB;
 
 /**

--- a/src/missing.php
+++ b/src/missing.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Opposite of parse_url()
  * Taken from https://stackoverflow.com/questions/4354904/php-parse-url-reverse-parsed-url.

--- a/tests/Tests/EventStoreTest.php
+++ b/tests/Tests/EventStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests;
 
 use KurrentDB\EventStore;

--- a/tests/Tests/StreamFeed/StreamFeedIteratorTest.php
+++ b/tests/Tests/StreamFeed/StreamFeedIteratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests\StreamFeed;
 
 use KurrentDB\StreamFeed\Entry;

--- a/tests/Tests/StreamFeed/StreamFeedTest.php
+++ b/tests/Tests/StreamFeed/StreamFeedTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests\StreamFeed;
 
 use KurrentDB\StreamFeed\EntryEmbedMode;

--- a/tests/Tests/StreamFeed/StreamUrlTest.php
+++ b/tests/Tests/StreamFeed/StreamUrlTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests\StreamFeed;
 
 use KurrentDB\StreamFeed\StreamUrl;

--- a/tests/Tests/TestCase.php
+++ b/tests/Tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests;
 
 use KurrentDB\EventStore;

--- a/tests/Tests/WritableEventCollectionTest.php
+++ b/tests/Tests/WritableEventCollectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests;
 
 use KurrentDB\Exception\InvalidWritableEventObjectException;

--- a/tests/Tests/WritableEventTest.php
+++ b/tests/Tests/WritableEventTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests;
 
 use KurrentDB\ValueObjects\Identity\UUID;

--- a/tests/Tests/WriteToStreamErrorHandlingTest.php
+++ b/tests/Tests/WriteToStreamErrorHandlingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\Tests;
 
 use KurrentDB\EventStore;

--- a/tests/ValueObjects/Tests/Identity/UUIDTest.php
+++ b/tests/ValueObjects/Tests/Identity/UUIDTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Tests\Identity;
 
 use KurrentDB\ValueObjects\Exception\InvalidNativeArgumentException;

--- a/tests/ValueObjects/Tests/StringLiteral/StringLiteralTest.php
+++ b/tests/ValueObjects/Tests/StringLiteral/StringLiteralTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Tests\StringLiteral;
 
 use KurrentDB\ValueObjects\StringLiteral\BasicStringLiteral;

--- a/tests/ValueObjects/Tests/TestCase.php
+++ b/tests/ValueObjects/Tests/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;

--- a/tests/ValueObjects/Tests/Util/UtilTest.php
+++ b/tests/ValueObjects/Tests/Util/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace KurrentDB\ValueObjects\Tests\Util;
 
 use KurrentDB\ValueObjects\Tests\TestCase;

--- a/tests/missingTest.php
+++ b/tests/missingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
## Summary
This PR resolves issue #63 by adding strict type declarations to the entire codebase, improving type safety and code quality.

## Changes Made
- **PHP-CS-Fixer Configuration**: Added  rule to 
- **Codebase-wide Application**: Applied  to all 54 PHP files in:
  -  (core library code)
  -  (test suite)  
  -  (performance benchmarks)
- **Type Safety Fix**: Fixed  method to properly cast PSR-7 Stream to string before 

## Technical Details
The implementation revealed and fixed a type compatibility issue where  was receiving a  object instead of a string. With strict types enabled, this properly caused a , which was resolved by casting the stream to string: .

## Benefits
- ✅ **Enhanced Type Safety**: Prevents implicit type conversions that could hide bugs
- ✅ **Early Error Detection**: Type mismatches are caught at runtime rather than causing subtle issues
- ✅ **Better IDE Support**: Improved autocompletion and static analysis capabilities  
- ✅ **Code Quality**: Enforces consistent strict typing across the entire codebase
- ✅ **Future-Proof**: Aligns with modern PHP best practices

## Testing
- All existing tests pass with strict types enabled
- The type fix ensures proper PSR-7 Stream handling
- No breaking changes to public API

## Validation
docker compose exec php bin/phpunit --testdox
PHPUnit 12.3.8 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.12
Configuration: /app/phpunit.xml.dist

........I........................................................ 65 / 67 ( 97%)
..                                                                67 / 67 (100%)

Time: 00:00.827, Memory: 20.00 MB

Event Store (KurrentDB\Tests\EventStore)
 ✔ Stream feed is successfully opened
 ✔ Event data is embedded with body mode
 ✔ Get single event with metadata from event stream
 ✔ Navigate stream using missing link returns null
 ✔ Wrong expected version should throw exception
 ✔ Unreacheable event store throws exception
 ✔ It can create a forward iterator
 ✔ Get single event from event stream
 ∅ Unauthorized streams throw unauthorized exception
   │
   │ Find a way to create a forbidden stream: create user, change stream acl...
   │
   │ /app/tests/Tests/EventStoreTest.php:327
   │
 ✔ Version is provided after writing to stream
 ✔ It can create a backward iterator
 ✔ Event stream feed head returns next link
 ✔ Event stream feed returns entries
 ✔ Stream is hard deleted
 ✔ Get single event with provided event id
 ✔ Fetching event of a deleted stream throws an exception
 ✔ Get event batch from event stream
 ✔ Event is written to stream
 ✔ Stream is soft deleted
 ✔ Unexistent stream should throw not found exception
 ✔ Deleted stream should throw an exception
 ✔ It can process the all stream with a forward iterator
 ✔ Client successfully connects to event store

Stream Feed (KurrentDB\Tests\StreamFeed\StreamFeed)
 ✔ Event embed mode is returned properly with data set #0
 ✔ Event embed mode is returned properly with data set #1
 ✔ Event embed mode is returned properly with data set #2
 ✔ Event embed mode is returned properly with data set #3
 ✔ Get link url returns proper url with data set #0
 ✔ Get link url returns proper url with data set #1
 ✔ Has link returns true on matching url
 ✔ Has link returns false on missing url
 ✔ Get link url returns null on missing url

Stream Feed Iterator (KurrentDB\Tests\StreamFeed\StreamFeedIterator)
 ✔ It should iterate single event asc
 ✔ It should iterate single event desc
 ✔ It should optimize http call on rewind
 ✔ It should iterate the second page
 ✔ It should be sorted desc
 ✔ It should be sorted asc

Stream Url (KurrentDB\Tests\StreamFeed\StreamUrl)
 ✔ It should be built from base url and name

String Literal (KurrentDB\ValueObjects\Tests\StringLiteral\StringLiteral)
 ✔ From native
 ✔ To native
 ✔ Same value as
 ✔ Is empty
 ✔ To string

UUID (KurrentDB\ValueObjects\Tests\Identity\UUID)
 ✔ Generate as string
 ✔ From native
 ✔ Same value as
 ✔ Invalid

Util (KurrentDB\ValueObjects\Tests\Util\Util)
 ✔ Class equals
 ✔ Get class as string

Writable Event (KurrentDB\Tests\WritableEvent)
 ✔ Event is converted to stream data

Writable Event Collection (KurrentDB\Tests\WritableEventCollection)
 ✔ Event collection is converted to stream data
 ✔ Invalid collection throws exception

Write To Stream Error Handling (KurrentDB\Tests\WriteToStreamErrorHandling)
 ✔ Write to stream with successful response but no location header returns false
 ✔ Write to stream with malformed location header returns false
 ✔ Write to stream handles http errors correctly with data set "@HTTP 400 Bad Request"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 201 Created with version"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 401 Unauthorized"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 404 Not Found"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 500 Internal Server Error"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 502 Bad Gateway"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 503 Service Unavailable"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 409 Conflict"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 410 Gone"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 429 Too Many Requests"
 ✔ Write to stream handles http errors correctly with data set "@HTTP 504 Gateway Timeout"

missing
 ✔ Urls are same before parse url and after unparse

OK, but there were issues!
Tests: 67, Assertions: 176, Incomplete: 1.
docker compose exec php bin/php-cs-fixer fix --dry-run -v --diff

Found 0 of 54 files that can be fixed in 0.239 seconds, 18.00 MB memory used

This enhancement improves code reliability without any breaking changes to the public API.

Fixes #63

🤖 Generated with [Claude Code](https://claude.ai/code)